### PR TITLE
Fix layer dropdown range in neuron view

### DIFF
--- a/bertviz/neuron_view.js
+++ b/bertviz/neuron_view.js
@@ -980,7 +980,7 @@ requirejs(['jquery', 'd3'],
 
         const layerSelect = $("#bertviz #layer");
         layerSelect.empty();
-        for (var i = 0; i < config.nHeads; i++) {
+        for (var i = 0; i < config.nLayers; i++) {
           layerSelect.append($("<option />").val(i).text(i));
         }
         layerSelect.val(config.layer).change();


### PR DESCRIPTION
I noticed that it was not possible to view all layers in models such as bert-large. 

I did not test this edit.