### PR TITLE
Added a feature: saving as png for neuron&model view, fixed a bug:(maybe)color inconsistency of neuron view

### DIFF
--- a/bertviz/model_view.js
+++ b/bertviz/model_view.js
@@ -78,6 +78,14 @@ requirejs(['jquery', 'd3'], function($, d3) {
                 .append('svg')
                 .attr("width", DIV_WIDTH)
                 .attr("height", config.divHeight)
+
+                // BEGIN TESTING AREA
+                // ID to get element
+                .attr("id", "Fsvg")
+                // Style to operative in separated file
+                .attr("xmlns", "http://www.w3.org/2000/svg")
+                // END TESTING AREA
+
                 .attr("fill", getBackgroundColor());
 
             renderAxisLabels();
@@ -180,6 +188,30 @@ requirejs(['jquery', 'd3'], function($, d3) {
             renderDetailText(config.rightText, "rightText", posRightText, y, layerIndex);
         }
 
+        function renderGraphDownload(new_svg_data) {
+                // to filestream, add the starter
+                var xml = new XMLSerializer().serializeToString(new_svg_data);
+                var imgsrc = 'data:image/svg+xml;base64,' + btoa(xml);
+                // update src to show the image
+                var canvas = document.createElement('canvas');
+                // set canvas size according to current div width and height
+                canvas.width = DIV_WIDTH;
+                canvas.height = config.divHeight;
+                var context = canvas.getContext('2d');
+                var image = new Image;
+                image.src = imgsrc;
+                image.onload = function () {
+                    context.drawImage(image, 0, 0);
+                    var canvasData = canvas.toDataURL("image/png");
+                    var a = document.createElement("a");
+                    a.download = "output.png";
+                    a.href = canvasData;
+                    document.getElementById("vis").appendChild(a);
+                    a.click();
+                }
+                // document.getElementById("vis").appendChild(canvas)
+        }
+        
         function renderDetailHeading(x, y, layerIndex, headIndex) {
             var fillColor = getTextColor();
             config.svg.append("text")
@@ -426,5 +458,12 @@ requirejs(['jquery', 'd3'], function($, d3) {
 
         initialize();
         render();
+        // After render the chart, add a button that trigger image generation
+        var downloadButton = document.createElement("button");
+        downloadButton.id = "downloadButton";
+        downloadButton.onclick = function () { renderGraphDownload(document.getElementById("Fsvg")) };
+        downloadButton.innerText = "Click to save the graph";
+        document.getElementById("vis").appendChild(downloadButton);
+    
 
     });

--- a/bertviz/neuron_view.js
+++ b/bertviz/neuron_view.js
@@ -75,6 +75,34 @@ requirejs(['jquery', 'd3'],
 
         const MIN_CONNECTOR_OPACITY = 0
 
+
+        function renderGraphDownload(new_svg_data) {
+            // to filestream, add the starter
+            console.log(new_svg_data);
+            var xml = new XMLSerializer().serializeToString(new_svg_data);
+            var imgsrc = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(xml)));
+            // update src to show the image
+            var canvas = document.createElement('canvas');
+            // set canvas size according to current div width and height
+            canvas.width = '950' ;
+            canvas.height = '500';
+            var context = canvas.getContext('2d');
+            var image = new Image;
+            image.src = imgsrc;
+            image.onload = function () {
+                context.drawImage(image, 0, 0);
+                var canvasData = canvas.toDataURL("image/png");
+                var a = document.createElement("a");
+                a.download = "output.png";
+                a.href = canvasData;
+                document.getElementById("vis").appendChild(a);
+                a.click();
+            }
+            // document.getElementById("vis").appendChild(canvas)
+        }
+
+
+
         function render() {
 
             var attnData = config.attention[config.filter];
@@ -88,6 +116,9 @@ requirejs(['jquery', 'd3'],
             var height = config.initialTextLength * BOXHEIGHT + HEIGHT_PADDING;
             var svg = d3.select(`#${config.rootDivId} #vis`)
                 .append('svg')
+                .attr("id", "Fsvg")
+                .attr("style", "background-color:" + getColor("background"))
+                .attr("xmlns", "http://www.w3.org/2000/svg")
                 .attr("width", "100%")
                 .attr("height", height + "px");
 
@@ -1009,5 +1040,12 @@ requirejs(['jquery', 'd3'],
         }
 
         render();
+        // After render the chart, add a button that trigger image generation
+        var downloadButton = document.createElement("button");
+        downloadButton.id = "downloadButton";
+        downloadButton.onclick = function () { renderGraphDownload(document.getElementById("Fsvg")) };
+        downloadButton.innerText = "Click to save the graph";
+        document.getElementById("vis").appendChild(downloadButton);
+
 
     });


### PR DESCRIPTION
Add feature: 
In Neuron / Model view, added a button at bottom that allows you to save the CURRENT view as a png file. Automatically triggers browser download.
The code is well-commented in model_view.js , there's no comment in neuron_view.js

Known Issues:
 - Head view and the q x k is not savable since they require the cursor to point at the tag.
 - Used default width&height for neuron view. Will improve later. 