### PR TITLE
Update setup.py to include IPython dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     license="Apache 2.0",
     packages=["bertviz"],
     include_package_data=True,
-    install_requires=["transformers>=2.0", "torch>=1.0", "tqdm", "boto3", "requests", "regex", "sentencepiece"],
+    install_requires=["transformers>=2.0", "torch>=1.0", "tqdm", "boto3", "requests", "regex", "sentencepiece", "IPython"],
 )


### PR DESCRIPTION
The package expects the IPython library to be available but does not include in the dependency list under `setup.py`'s 'install_requires=[...]` list of string literals. This commit adds the dependency. 

Prior to this the work around needed is to-in a shell-in the python env run `pip install IPython`-after running `pip intall bertviz` and then do your stuffs.

ping @jvig @jessevig 